### PR TITLE
Use regex to parse input

### DIFF
--- a/debugraph.html
+++ b/debugraph.html
@@ -69,10 +69,9 @@ function covertToGraphData(s) {
     
     var lines = s.split("\n");
 
-    var nodeIdList = lines[0]
-        .trim().split(" ").filter(function(e) { return e.length != 0; });
-    var edgeString = lines[1]
-        .trim().split(" ").filter(function(e) { return e.length != 0; });
+    var regex = /[^\(\s]+(\([^\)]+\))*/g;
+    var nodeIdList = lines[0].match(regex);
+    var edgeString = lines[1].match(regex);
 
     var graph = { nodes: [], edges: [] };
 


### PR DESCRIPTION
Allows for spaces in labels.

Signed-off-by: Jihoon Chung jihoon@gmail.com
